### PR TITLE
Bump version to 1.0.3 and update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spree_ipay (1.0.2)
+    spree_ipay (1.0.3)
       deface (~> 1.9.0)
       httparty (~> 0.16.0)
       rails (~> 7.1.4)

--- a/spree_ipay.gemspec
+++ b/spree_ipay.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'spree_ipay'
-  spec.version       = '1.0.2'
+  spec.version       = '1.0.3'
   spec.authors       = ['Simon Njunge']
   spec.email         = ['simon.k@cloudoon.com']
   spec.summary       = 'iPay payment integration for Spree Commerce'


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Bump gem version from 1.0.2 to 1.0.3


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spree_ipay.gemspec</strong><dd><code>Version bump to 1.0.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spree_ipay.gemspec

- Updated version number from 1.0.2 to 1.0.3


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/spree_ipay/pull/12/files#diff-83cc03bd476d0bccdf695f15782354abaefeccc4424d59a42e08cc3308a322d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>